### PR TITLE
fix: better compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This project is built using the following technologies:
    npm run dev
    ```
 
-4. Open the app in your browser at `http://localhost:3000`.
+4. Open the app in your browser at `http://localhost:5173`.
 
 ---
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -193,7 +193,7 @@ function importHosts(newHosts: CaddyHost[]) {
                 <span>{{ host.fileServer ? 'File Server' : 'Reverse Proxy' }}</span>
                 <div class="flex gap-1">
                   <Lock v-if="host.tls?.email || host.tls?.selfSigned" class="w-4 h-4" title="TLS Enabled" />
-                  <Zap v-if="host.gzip" class="w-4 h-4" title="Gzip Enabled" />
+                  <Zap v-if="host.encode" class="w-4 h-4" title="Compression Enabled" />
                 </div>
               </div>
               <span v-if="host.fileServer" class="block mt-1 text-sm">

--- a/src/components/CaddyConfig.vue
+++ b/src/components/CaddyConfig.vue
@@ -65,7 +65,7 @@ onMounted(() => {
         alias: 'operator'
       },
       'option': {
-        pattern: /\b(browse|internal|gzip|brotli|php_fastcgi|uri|copy_headers)\b/,
+        pattern: /\b(browse|internal|encode|brotli|php_fastcgi|uri|copy_headers)\b/,
         alias: 'property'
       },
       'number': {
@@ -115,12 +115,10 @@ const caddyConfig = computed(() => {
       }
       
       // Handle encoding directives
-      if (host.performance?.brotli && host.gzip) {
-        lines.push('    encode brotli gzip');
-      } else if (host.gzip) {
-        lines.push('    encode gzip');
-      } else if (host.performance?.brotli) {
-        lines.push('    encode brotli gzip');
+      if (host.performance?.brotli) {
+        lines.push('    encode zstd br gzip');
+      } else if (host.encode) {
+        lines.push('    encode');
       }
 
       // Security settings

--- a/src/components/HostForm.vue
+++ b/src/components/HostForm.vue
@@ -22,7 +22,7 @@ const host = ref<CaddyHost>(props.initialHost || {
     php: false,
     hide: []
   },
-  gzip: false,
+  encode: false,
   tls: {
     email: '',
     selfSigned: false
@@ -154,8 +154,8 @@ function applyPreset(preset: PresetConfig) {
 
         <div class="form-group">
           <label class="checkbox">
-            <input type="checkbox" v-model="host.gzip" />
-            Enable Gzip compression
+            <input type="checkbox" v-model="host.encode" />
+            Enable Gzip and Zstandard compression
           </label>
         </div>
 
@@ -311,7 +311,7 @@ function applyPreset(preset: PresetConfig) {
             <div class="form-group">
               <label class="checkbox">
                 <input type="checkbox" v-model="host.performance.brotli" />
-                Enable Brotli compression
+                Enable Brotli compression (requires <a href="https://caddyserver.com/docs/modules/http.encoders.br">an additional module</a>)
               </label>
             </div>
 

--- a/src/components/ImportModal.vue
+++ b/src/components/ImportModal.vue
@@ -53,7 +53,7 @@ function parseCaddyfile(content: string): CaddyHost[] {
     const host: CaddyHost = {
       id: crypto.randomUUID(),
       domain,
-      gzip: false
+      encode: false
     };
 
     for (let i = 1; i < lines.length; i++) {
@@ -81,8 +81,8 @@ function parseCaddyfile(content: string): CaddyHost[] {
         }
       } else if (line.startsWith('reverse_proxy')) {
         host.reverseProxy = line.split(' ').slice(1).join(' ');
-      } else if (line.startsWith('encode gzip')) {
-        host.gzip = true;
+      } else if (line.startsWith('encode')) {
+        host.encode = true;
       } else if (line.startsWith('tls')) {
         const email = line.split(' ')[1];
         host.tls = {

--- a/src/types/caddy.ts
+++ b/src/types/caddy.ts
@@ -13,7 +13,7 @@ export interface CaddyHost {
     email?: string;
     selfSigned?: boolean;
   };
-  gzip?: boolean;
+  encode?: boolean;
   basicAuth?: {
     username: string;
     password: string;


### PR DESCRIPTION
Since Caddy 2.9, using `encode` alone will set proper defaults and will enable Zstandard (now supported by most browsers).

This patch also fixes Brotli support (must be `br` instead of `brotli`, and requires an extra module).